### PR TITLE
Split header and content transfer explicitly

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 pkg/
 *~
+.DS_Store

--- a/protocol/client.go
+++ b/protocol/client.go
@@ -85,7 +85,7 @@ func (c *Client) Upstream(client net.Conn, server tunnel.Writer) {
 
 	for {
 		n, err := client.Read(buf)
-		server.WriteUser(buf[:n])
+		server.WriteContent(buf[:n])
 		if err != nil {
 			break
 		}
@@ -95,7 +95,7 @@ func (c *Client) Upstream(client net.Conn, server tunnel.Writer) {
 func (c *Client) Downstream(client net.Conn, server tunnel.Reader) {
 	buf := make([]byte, compression.BufferSize)
 	for {
-		n, err := server.ReadUser(buf, false)
+		n, err := server.ReadContent(buf)
 		client.Write(buf[:n])
 		if err != nil {
 			break

--- a/protocol/server.go
+++ b/protocol/server.go
@@ -91,7 +91,7 @@ func (s *Server) ParseUserHeader(local tunnel.Reader) (UDPconnect bool, addrPort
 func (s *Server) Upstream(local tunnel.Reader, remote net.Conn) {
 	buf := make([]byte, compression.BufferSize)
 	for {
-		n, err := local.ReadUser(buf, false)
+		n, err := local.ReadContent(buf)
 		remote.Write(buf[:n])
 		if err != nil {
 			break
@@ -103,7 +103,7 @@ func (s *Server) Downstream(local tunnel.Writer, remote net.Conn) {
 	buf := make([]byte, compression.BufferSize)
 	for {
 		n, err := remote.Read(buf)
-		local.WriteUser(buf[0:n])
+		local.WriteContent(buf[0:n])
 		if err != nil {
 			break
 		}

--- a/tunnel/tunnel.go
+++ b/tunnel/tunnel.go
@@ -8,6 +8,9 @@ type Reader interface {
 
 	// Read User data
 	ReadUser(p []byte, full bool) (int, error)
+
+	// Read Content data
+	ReadContent(p []byte) (int, error)
 }
 
 type Writer interface {
@@ -16,4 +19,7 @@ type Writer interface {
 
 	// Write User data
 	WriteUser(p []byte) (n int, err error)
+
+	// Write Content data
+	WriteContent(p []byte) (n int, err error)
 }


### PR DESCRIPTION
As the title describes, we should split header and content transfer explicitly in order to future compression implementation.
